### PR TITLE
Fix Indentation On The `node-exporter-full` Dashboard

### DIFF
--- a/infrastructure/base/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/base/kube-prometheus-stack/helmrelease.yaml
@@ -55,7 +55,7 @@ spec:
           # https://grafana.com/grafana/dashboards/15918-chaos-mesh-overview/
           chaos-mesh-overview:
             gnetId: 15918
-            datasource: Prometheus
+            datasource: ChaosMesh
 
       # Grafana datasources - Loki and Tempo will be added
       additionalDataSources:


### PR DESCRIPTION
This PR aims to fix the following issue:

```bash
flux get  helmrelease -n=monitoring
```

```
kube-prometheus-stack   79.4.1          False           False   Helm install failed for release monitoring/kube-prometheus-stack with chart kube-prometheus-stack@79.4.1: template: kube-prometheus-stack/charts/grafana/templates/deployment.yaml:36:28: executing "kube-prometheus-stack/charts/grafana/templates/deployment.yaml" at <include "grafana.configData" .>: error calling include: template: kube-prometheus-stack/charts/grafana/templates/_config.tpl:87:23: executing "grafana.configData" at <$value>: wrong type for value; expected map[string]interface {}; got string

```