### PR TITLE
Fix(Loki HelmRelease): Add Schema and Storage Configuration

### DIFF
--- a/infrastructure/base/loki/helmrelease.yaml
+++ b/infrastructure/base/loki/helmrelease.yaml
@@ -24,6 +24,7 @@ spec:
       limits_config:
         volume_enabled: true
       
+      useTestSchema: false
       storage_config:
         boltdb_shipper:
           active_index_directory: /var/loki/index


### PR DESCRIPTION
This PR fixes the HelmRelease installation failure for Loki, which was caused by a missing `schema_config` definition.
The Helm chart requires an explicit schema configuration unless useTestSchema is enabled (which is only suitable for non-persistent testing).

```bash
kubectl -n monitoring describe helmrelease loki 
```
```
2025-11-12T13:15:41.919716682Z: applying CustomResourceDefinition(s) with policy Create
  Warning  InstallFailed  4m4s (x4 over 12m)  helm-controller  (combined from similar events): Helm install failed for
release monitoring/loki with chart loki@6.46.0: execution error at (loki/templates/validate.yaml:40:4): You must provide a
schema_config for Loki, one is not provided as this will be individual for every Loki cluster. See
https://grafana.com/docs/loki/latest/operations/storage/schema/ for schema information. For quick testing (with no
persistence) add `--set loki.useTestSchema=true`
```