### PR TITLE
Chore(Loki): Adjust `memcached` Resource Requests and Limits

### DIFF
--- a/infrastructure/base/loki/helmrelease.yaml
+++ b/infrastructure/base/loki/helmrelease.yaml
@@ -58,6 +58,26 @@ spec:
       ingress:
         enabled: false
     
+    # Disable unnecessary caches for single-binary mode
+    # (no microservices)
+    memcachedChunks:
+      enabled: false
+      # resources:
+      #   requests:
+      #     cpu: 
+      #     memory: 128Mi
+      #   limits:
+      #     cpu: 200m
+      #     memory: 256Mi
+
+    memcachedFrontend:
+      enabled: false
+    memcachedIndexQueries:
+      enabled: false
+    memcachedIndexWrites:
+      enbaled: false
+
+    
     # Disable components not needed for single binary mode
     read:
       replicas: 0

--- a/infrastructure/production/loki/kustomization.yaml
+++ b/infrastructure/production/loki/kustomization.yaml
@@ -3,8 +3,7 @@ kind: Kustomization
 resources:
   - ../../base/loki
 
-patches:
-  # Patch Loki persistence size
+patchesJson6902:
   - target:
       kind: HelmRelease
       name: loki
@@ -13,3 +12,10 @@ patches:
       - op: replace
         path: /spec/values/singleBinary/persistence/size
         value: 1Gi
+
+patches:
+  - path: patch-resources.yaml
+    target:
+      kind: HelmRelease
+      name: loki
+      namespace: monitoring

--- a/infrastructure/production/loki/patch-resources.yaml
+++ b/infrastructure/production/loki/patch-resources.yaml
@@ -1,0 +1,52 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  values:
+    singleBinary:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi   
+
+    memcachedChunks:
+      enabled: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+    memcachedFrontend:
+      enabled: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+    memcachedIndexQueries:
+      enabled: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi
+    memcachedIndexWrites:
+      enabled: true
+      resources:
+        requests:
+          cpu: 50m
+          memory: 128Mi
+        limits:
+          cpu: 200m
+          memory: 256Mi


### PR DESCRIPTION
This PR aims to avoid `Pending` state of Loki's `memcached` pods