### PR TITLE
Fix(Grafana): Remove Duplicate Prometheus Datasource

### DIFF
--- a/infrastructure/base/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/base/kube-prometheus-stack/helmrelease.yaml
@@ -59,11 +59,6 @@ spec:
 
       # Grafana datasources - Loki and Tempo will be added
       additionalDataSources:
-        - name: Prometheus
-          type: prometheus
-          url: http://kube-prometheus-stack-prometheus.monitoring.svc.cluster.local:9090
-          access: proxy
-          isDefault: true
         - name: Loki
           type: loki
           url: http://loki-gateway.monitoring.svc.cluster.local


### PR DESCRIPTION
A Prometheus source is already created by default.