### PR TITLE
Disable Memcached OR Adjust Memory Requests

### DIFF
--- a/infrastructure/base/loki/helmrelease.yaml
+++ b/infrastructure/base/loki/helmrelease.yaml
@@ -49,33 +49,28 @@ spec:
         enabled: true
         size: "<override-with-kustomize>"
     
+    memcached:   
+      enabled: <override-with-kustomize>
+
+    memcachedExporter:
+      enabled: <override-with-kustomize>
+      # image:
+      #   repository: prom/memcached-exporter
+      #   tag: v0.15.3
+      #   pullPolicy: IfNotPresent
+      # resources:
+      #   requests: {}
+      #   limits: {}
+    resultsCache:
+      enabled: <override-with-kustomize>
+      allocatedMemory: <override-with-kustomize> # default: 1024
+    chunksCache:
+      enabled: <override-with-kustomize>
+      allocatedMemory: <override-with-kustomize> # default: 8192
+      
     # Deploy the Gateway (nginx)
     gateway:
       enabled: true
-      service:
-        enabled: true
-        type: ClusterIP
-      ingress:
-        enabled: false
-    
-    # Disable unnecessary caches for single-binary mode
-    # (no microservices)
-    memcachedChunks:
-      enabled: false
-      # resources:
-      #   requests:
-      #     cpu: 
-      #     memory: 128Mi
-      #   limits:
-      #     cpu: 200m
-      #     memory: 256Mi
-
-    memcachedFrontend:
-      enabled: false
-    memcachedIndexQueries:
-      enabled: false
-    memcachedIndexWrites:
-      enbaled: false
 
     
     # Disable components not needed for single binary mode

--- a/infrastructure/production/loki/patch-resources.yaml
+++ b/infrastructure/production/loki/patch-resources.yaml
@@ -12,41 +12,15 @@ spec:
           memory: 256Mi
         limits:
           cpu: 500m
-          memory: 512Mi   
+          memory: 512Mi
 
-    memcachedChunks:
-      enabled: true
-      resources:
-        requests:
-          cpu: 50m
-          memory: 128Mi
-        limits:
-          cpu: 200m
-          memory: 256Mi
-    memcachedFrontend:
-      enabled: true
-      resources:
-        requests:
-          cpu: 50m
-          memory: 128Mi
-        limits:
-          cpu: 200m
-          memory: 256Mi
-    memcachedIndexQueries:
-      enabled: true
-      resources:
-        requests:
-          cpu: 50m
-          memory: 128Mi
-        limits:
-          cpu: 200m
-          memory: 256Mi
-    memcachedIndexWrites:
-      enabled: true
-      resources:
-        requests:
-          cpu: 50m
-          memory: 128Mi
-        limits:
-          cpu: 200m
-          memory: 256Mi
+    memcached:   
+      enabled: false
+
+    memcachedExporter:
+      enabled: false
+
+    resultsCache:
+      enabled: false
+    chunksCache:
+      enabled: false


### PR DESCRIPTION
We are not really in production so this PR aims to disable `memcached` option on `loki` to guarantee we have resources for all containers.
An option to adjust memory consumption has been also added!