### PR TITLE
Fix(Loki): Provide an `object storage backend` For Scalable Targets (Read/Write/Backend)

### DIFF
--- a/infrastructure/base/loki/helmrelease.yaml
+++ b/infrastructure/base/loki/helmrelease.yaml
@@ -43,10 +43,13 @@ spec:
               prefix: index_
               period: 24h
     
-    # Single Binary Deployment (Mutally exclusive with SSD and Microservice modes)
+    # Single Binary Deployment 
+    #  - Mutally exclusive with Microservice mode
+    #  - Complementatry to SSD mode (replicas should be 1)
+
     # For small Loki installations up to a few 10's of GB per day, or for testing and development.
     singleBinary:
-      replicas: 0
+      replicas: "<override-with-kustomize>" # default: 0
       persistence:
         enabled: true
         size: "<override-with-kustomize>" # default: 10Gi

--- a/infrastructure/production/loki/patch-resources.yaml
+++ b/infrastructure/production/loki/patch-resources.yaml
@@ -5,14 +5,12 @@ metadata:
   namespace: monitoring
 spec:
   values:
+
     singleBinary:
-      resources:
-        requests:
-          cpu: 100m
-          memory: 256Mi
-        limits:
-          cpu: 500m
-          memory: 512Mi
+      replicas: 1
+      persistence:
+        enabled: true
+        size: 1Gi
 
     memcached:   
       enabled: true


### PR DESCRIPTION
This PR aims to fix the following issue:

```bash
flux -n=monitoring get hr loki 
```

```
NAME    REVISION        SUSPENDED       READY   MESSAGE 
loki    6.46.0          False           False   Helm upgrade failed for release monitoring/loki with chart
loki@6.46.0: execution error at (loki/templates/validate.yaml:19:4): Cannot run scalable targets
(backend, read, write) or distributed targets without an object storage backend.
```