### PR TITLE
Fix Loki `singleBinary` Mode Configuration to Display Logs on Grafana

### DIFF
--- a/infrastructure/base/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/base/kube-prometheus-stack/helmrelease.yaml
@@ -61,12 +61,12 @@ spec:
       additionalDataSources:
         - name: Loki
           type: loki
-          url: http://loki.monitoring.svc.cluster.local
+          url: http://loki.monitoring.svc.cluster.local:3100
           access: proxy
           isDefault: false
         - name: Tempo
           type: tempo
-          url: http://tempo.monitoring.svc.cluster.local:3100
+          url: http://tempo.monitoring.svc.cluster.local:3200
           access: proxy
           isDefault: false
         - name: ChaosMesh

--- a/infrastructure/base/loki/helmrelease.yaml
+++ b/infrastructure/base/loki/helmrelease.yaml
@@ -101,7 +101,7 @@ spec:
       enabled: true
       enableTracing: true
       clients:
-        - url: http://loki.monitoring.svc.cluster.local/loki/api/v1/push
+        - url: http://loki.monitoring.svc.cluster.local:3100/loki/api/v1/push
       positions:
         filename: /run/promtail/positions.yaml
     sidecar:


### PR DESCRIPTION
This PR aims to fix `Promtail` and `Loki` integrations on `Grafana` to display logs.

This PR resolves:
- [x] #15
- [x] #17 