### PR TITLE
Enable Tempo Query and Expose Tempo API for Grafana Explore

### DIFF
--- a/infrastructure/base/tempo/helmrelease.yaml
+++ b/infrastructure/base/tempo/helmrelease.yaml
@@ -16,14 +16,16 @@ spec:
       interval: 12h
   values:
     tempo:
-      repository: grafana/tempo
-      tag: latest
+      server:
+        http_listen_port: 3200
       
       storage:
         trace:
           backend: local
           local:
             path: /var/tempo/traces
+          wal:
+            path: /var/tempo/wal
       
       receivers:
         jaeger:
@@ -34,13 +36,18 @@ spec:
               endpoint: 0.0.0.0:14250
         otlp:
           protocols:
-            http:
-              endpoint: 0.0.0.0:4318
             grpc:
               endpoint: 0.0.0.0:4317
-        zipkin:
-          endpoint: 0.0.0.0:9411
+            http:
+              endpoint: 0.0.0.0:4318
+
+    tempoQuery:
+      enabled: true
+      service:
+        port: 16686
     
+    serviceMonitor:
+      enabled: true
     persistence:
       enabled: true
       size: "<override-with-kustomize>"


### PR DESCRIPTION
This PR enables Tempo Query and correctly exposes the Tempo HTTP API (3200) so Grafana can query tracing data through Explore.

This PR aims to resolve issue #20.