### PR TITLE
Add Ceph Distributed and Self-Healing Storage via `rook-ceph` Helm Chart

### DIFF
--- a/clusters/production/infrastructure.yaml
+++ b/clusters/production/infrastructure.yaml
@@ -33,12 +33,31 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: storage
+  namespace: flux-system
+spec:
+  interval: 10m
+  dependsOn:
+    - name: crds
+    - name: network
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/production/infrastructure/storage
+  prune: false
+  wait: true
+  timeout: 10m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: observability
   namespace: flux-system
 spec:
   interval: 10m
   dependsOn:
     - name: network
+    - name: storage # provide S3-compatible api for tempo
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/clusters/production/infrastructure/storage/rook-ceph-cluster.yaml
+++ b/clusters/production/infrastructure/storage/rook-ceph-cluster.yaml
@@ -1,19 +1,21 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: rook-ceph-operator
+  name: rook-ceph-cluster
   namespace: flux-system
 spec:
   interval: 10m
-  path: ./infrastructure/staging/rook-ceph-operator
+  path: ./infrastructure/production/rook-ceph-cluster
   sourceRef:
     kind: GitRepository
     name: flux-system
+  dependsOn:
+    - name: rook-ceph-operator
   wait: true
   prune: false
-  timeout: 5m
+  timeout: 15m
   healthChecks:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: rook-ceph-operator
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook-ceph
       namespace: rook-ceph

--- a/clusters/production/infrastructure/storage/rook-ceph-operator.yaml
+++ b/clusters/production/infrastructure/storage/rook-ceph-operator.yaml
@@ -6,13 +6,11 @@ metadata:
 spec:
   interval: 10m
   path: ./infrastructure/production/rook-ceph-operator
-  prune: true
   sourceRef:
     kind: GitRepository
     name: flux-system
-  dependsOn:
-    - name: kube-prometheus-stack
   wait: true
+  prune: false
   timeout: 5m
   healthChecks:
     - apiVersion: apps/v1

--- a/clusters/production/infrastructure/storage/rook-ceph-operator.yaml
+++ b/clusters/production/infrastructure/storage/rook-ceph-operator.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rook-ceph-operator
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./infrastructure/production/rook-ceph-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: kube-prometheus-stack
+  wait: true
+  timeout: 5m
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: rook-ceph-operator
+      namespace: rook-ceph

--- a/clusters/production/infrastructure/storage/rook-ceph-operator.yaml
+++ b/clusters/production/infrastructure/storage/rook-ceph-operator.yaml
@@ -9,6 +9,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  dependsOn:
+    - name: cilium
   wait: true
   prune: false
   timeout: 5m

--- a/clusters/staging/infrastructure.yaml
+++ b/clusters/staging/infrastructure.yaml
@@ -33,12 +33,31 @@ spec:
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
+  name: storage
+  namespace: flux-system
+spec:
+  interval: 10m
+  dependsOn:
+    - name: crds
+    - name: network
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./clusters/staging/infrastructure/storage
+  prune: false
+  wait: true
+  timeout: 10m
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
   name: observability
   namespace: flux-system
 spec:
   interval: 10m
   dependsOn:
     - name: network
+    - name: storage # provide S3-compatible api for tempo
   sourceRef:
     kind: GitRepository
     name: flux-system

--- a/clusters/staging/infrastructure/storage/rook-ceph-cluster.yaml
+++ b/clusters/staging/infrastructure/storage/rook-ceph-cluster.yaml
@@ -1,19 +1,21 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: rook-ceph-operator
+  name: rook-ceph-cluster
   namespace: flux-system
 spec:
   interval: 10m
-  path: ./infrastructure/staging/rook-ceph-operator
+  path: ./infrastructure/staging/rook-ceph-cluster
   sourceRef:
     kind: GitRepository
     name: flux-system
+  dependsOn:
+    - name: rook-ceph-operator
   wait: true
   prune: false
-  timeout: 5m
+  timeout: 15m
   healthChecks:
-    - apiVersion: apps/v1
-      kind: Deployment
-      name: rook-ceph-operator
+    - apiVersion: ceph.rook.io/v1
+      kind: CephCluster
+      name: rook-ceph
       namespace: rook-ceph

--- a/clusters/staging/infrastructure/storage/rook-ceph-operator.yaml
+++ b/clusters/staging/infrastructure/storage/rook-ceph-operator.yaml
@@ -1,0 +1,21 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: rook-ceph-operator
+  namespace: flux-system
+spec:
+  interval: 10m
+  path: ./infrastructure/staging/rook-ceph-operator
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  dependsOn:
+    - name: kube-prometheus-stack
+  wait: true
+  timeout: 5m
+  healthChecks:
+    - apiVersion: apps/v1
+      kind: Deployment
+      name: rook-ceph-operator
+      namespace: rook-ceph

--- a/clusters/staging/infrastructure/storage/rook-ceph-operator.yaml
+++ b/clusters/staging/infrastructure/storage/rook-ceph-operator.yaml
@@ -9,6 +9,8 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  dependsOn:
+    - name: cilium
   wait: true
   prune: false
   timeout: 5m

--- a/infrastructure/base/rook-ceph-cluster/helmrelease.yaml
+++ b/infrastructure/base/rook-ceph-cluster/helmrelease.yaml
@@ -1,0 +1,55 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: rook-ceph-cluster
+      version: "^1.18.8"
+      sourceRef:
+        kind: HelmRepository
+        name: rook-ceph
+        namespace: rook-ceph
+      interval: 12h
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  values:
+    monitoring:
+      # -- Enable Prometheus integration, will also create necessary RBAC rules to allow Operator to create ServiceMonitors.
+      # Monitoring requires Prometheus to be pre-installed
+      enabled: true
+      # -- Whether to disable the metrics reported by Ceph. If false, the prometheus mgr module and Ceph exporter are enabled
+      metricsDisabled: false
+      # -- Whether to create the Prometheus rules for Ceph alerts
+      createPrometheusRules: true
+
+    # enable the ceph dashboard for viewing cluster status
+    dashboard:
+      enabled: true
+      # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
+      # urlPrefix: /ceph-dashboard
+      # serve the dashboard at the given port.
+      # port: 8443
+      # Serve the dashboard using SSL (if using ingress to expose the dashboard and `ssl: true` you need to set
+      # the corresponding "backend protocol" annotation(s) for your ingress controller of choice)
+      ssl: <override-with-kustomize>
+
+    network:
+      connections:
+        # Whether to encrypt the data in transit across the wire to prevent eavesdropping the data on the network.
+        # Encryption requires the 5.11 kernel for the latest nbd and cephfs drivers
+        encryption:
+          enabled: <override-with-kustomize>
+        # Whether to compress the data in transit across the wire. The default is false.
+        # The kernel requirements above for encryption also apply to compression.
+        compression:
+          enabled: <override-with-kustomize>
+        # Whether to require communication over msgr2. If true, the msgr v1 port (6789) will be disabled
+        # and clients will be required to connect to the Ceph cluster with the v2 port (3300).
+        # Requires a kernel that supports msgr v2 (kernel 5.11 or CentOS 8.4 or newer).
+        requireMsgr2: <override-with-kustomize>

--- a/infrastructure/base/rook-ceph-cluster/helmrelease.yaml
+++ b/infrastructure/base/rook-ceph-cluster/helmrelease.yaml
@@ -28,16 +28,16 @@ spec:
       # -- Whether to create the Prometheus rules for Ceph alerts
       createPrometheusRules: true
 
-    # enable the ceph dashboard for viewing cluster status
-    dashboard:
-      enabled: true
-      # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
-      # urlPrefix: /ceph-dashboard
-      # serve the dashboard at the given port.
-      # port: 8443
-      # Serve the dashboard using SSL (if using ingress to expose the dashboard and `ssl: true` you need to set
-      # the corresponding "backend protocol" annotation(s) for your ingress controller of choice)
-      ssl: <override-with-kustomize>
+    cephClusterSpec:
+      dashboard:
+        enabled: true
+        # serve the dashboard under a subpath (useful when you are accessing the dashboard via a reverse proxy)
+        # urlPrefix: /ceph-dashboard
+        # serve the dashboard at the given port.
+        # port: 8443
+        # Serve the dashboard using SSL (if using ingress to expose the dashboard and `ssl: true` you need to set
+        # the corresponding "backend protocol" annotation(s) for your ingress controller of choice)
+        ssl: <override-with-kustomize>
 
     network:
       connections:

--- a/infrastructure/base/rook-ceph-cluster/helmrepository.yaml
+++ b/infrastructure/base/rook-ceph-cluster/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  interval: 24h
+  url: https://charts.rook.io/release

--- a/infrastructure/base/rook-ceph-cluster/kustomization.yaml
+++ b/infrastructure/base/rook-ceph-cluster/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/infrastructure/base/rook-ceph-cluster/namespace.yaml
+++ b/infrastructure/base/rook-ceph-cluster/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph

--- a/infrastructure/base/rook-ceph-operator/helmrelease.yaml
+++ b/infrastructure/base/rook-ceph-operator/helmrelease.yaml
@@ -1,0 +1,31 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: rook-ceph
+      version: "^1.18.8"
+      sourceRef:
+        kind: HelmRepository
+        name: rook-ceph
+        namespace: rook-ceph
+      interval: 12h
+  install:
+    crds: Create
+  upgrade:
+    crds: CreateReplace
+  values:
+    # Discover devices on all nodes
+    enableDiscoveryDaemon: true
+
+    # useful for administrative actions where the rook operator must be scaled down
+    scaleDownOperator: true
+
+    # Enable monitoring, depends on Prometheus chart
+    monitoring:
+      enabled: true
+    

--- a/infrastructure/base/rook-ceph-operator/helmrelease.yaml
+++ b/infrastructure/base/rook-ceph-operator/helmrelease.yaml
@@ -22,9 +22,6 @@ spec:
     # Discover devices on all nodes
     enableDiscoveryDaemon: true
 
-    # useful for administrative actions where the rook operator must be scaled down
-    scaleDownOperator: true
-
     # Enable monitoring, depends on Prometheus chart
     monitoring:
       enabled: true

--- a/infrastructure/base/rook-ceph-operator/helmrepository.yaml
+++ b/infrastructure/base/rook-ceph-operator/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1beta2
+kind: HelmRepository
+metadata:
+  name: rook-ceph
+  namespace: rook-ceph
+spec:
+  interval: 24h
+  url: https://charts.rook.io/release

--- a/infrastructure/base/rook-ceph-operator/kustomization.yaml
+++ b/infrastructure/base/rook-ceph-operator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/infrastructure/base/rook-ceph-operator/namespace.yaml
+++ b/infrastructure/base/rook-ceph-operator/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: rook-ceph

--- a/infrastructure/production/rook-ceph-cluster/kustomization.yaml
+++ b/infrastructure/production/rook-ceph-cluster/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/rook-ceph-cluster
+
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: rook-ceph-cluster
+      namespace: rook-ceph

--- a/infrastructure/production/rook-ceph-cluster/patch.yaml
+++ b/infrastructure/production/rook-ceph-cluster/patch.yaml
@@ -5,9 +5,10 @@ metadata:
   namespace: rook-ceph
 spec:
   values:
-    dashboard:
-      enabled: true
-      ssl: true
+    cephClusterSpec:
+      dashboard:
+        enabled: true
+        ssl: true
 
     network:
       connections:

--- a/infrastructure/production/rook-ceph-cluster/patch.yaml
+++ b/infrastructure/production/rook-ceph-cluster/patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+spec:
+  values:
+    dashboard:
+      enabled: true
+      ssl: true
+
+    network:
+      connections:
+        encryption:
+          enabled: true
+        compression:
+          enabled: true
+        requireMsgr2: true

--- a/infrastructure/production/rook-ceph-operator/kustomization.yaml
+++ b/infrastructure/production/rook-ceph-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/rook-ceph-operator

--- a/infrastructure/staging/rook-ceph-cluster/kustomization.yaml
+++ b/infrastructure/staging/rook-ceph-cluster/kustomization.yaml
@@ -9,3 +9,8 @@ patches:
       kind: HelmRelease
       name: rook-ceph-cluster
       namespace: rook-ceph
+  - path: patch-resources.yaml
+    target:
+      kind: HelmRelease
+      name: rook-ceph-cluster
+      namespace: rook-ceph

--- a/infrastructure/staging/rook-ceph-cluster/kustomization.yaml
+++ b/infrastructure/staging/rook-ceph-cluster/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/rook-ceph-cluster
+
+patches:
+  - path: patch.yaml
+    target:
+      kind: HelmRelease
+      name: rook-ceph-cluster
+      namespace: rook-ceph

--- a/infrastructure/staging/rook-ceph-cluster/patch-resources.yaml
+++ b/infrastructure/staging/rook-ceph-cluster/patch-resources.yaml
@@ -27,9 +27,9 @@ spec:
         osd:
           requests:
             cpu: "500m"
-            memory: "1Gi"
+            memory: "750Mi"
           limits:
-            memory: "2Gi"
+            memory: "1Gi"
 
     # This defines a Ceph pool used by RBD (block storage).
     # PVCs using `rook-ceph-block` → use this pool
@@ -37,26 +37,75 @@ spec:
     cephBlockPools:
       - name: ceph-blockpool
         spec:
-          # This tells Ceph what “failure” means. (host = a Kubernetes node)
-          # Ceph will try to put replicas on different nodes
           failureDomain: host
-          # replication factor, ONE copy of data for staging
           replicated:
             size: 1
-    
+        storageClass:
+          enabled: true
+          name: ceph-block
+          annotations: {}
+          labels: {}
+          isDefault: true
+          reclaimPolicy: Delete
+          allowVolumeExpansion: true
+          volumeBindingMode: "Immediate"
+          mountOptions: []
+
+          allowedTopologies: []
+          parameters:
+            imageFormat: "2"
+            imageFeatures: layering
+
+            csi.storage.k8s.io/provisioner-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-expand-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-publish-secret-name: rook-csi-rbd-provisioner
+            csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/node-stage-secret-name: rook-csi-rbd-node
+            csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/fstype: ext4
+
     cephObjectStores:
       - name: ceph-objectstore
         spec:
+          metadataPool:
+            failureDomain: host
+            replicated:
+              size: 3
+          dataPool:
+            failureDomain: host
+            erasureCoded:
+              dataChunks: 2
+              codingChunks: 1
+            parameters:
+              bulk: "true"
+          preservePoolsOnDelete: true
           gateway:
             port: 80
-            instances: 1
             resources:
               limits:
                 memory: "1Gi"
               requests:
                 cpu: "200m"
                 memory: "512Mi"
-    
+
+            instances: 1
+            priorityClassName: system-cluster-critical
+        storageClass:
+          enabled: true
+          name: ceph-bucket
+          reclaimPolicy: Delete
+          volumeBindingMode: "Immediate"
+          annotations: {}
+          labels: {}
+          parameters:
+            region: us-east-1
+        ingress:
+          enabled: false
+        route:
+          enabled: false
+
     cephFileSystems:
       - name: ceph-filesystem
         spec:
@@ -70,3 +119,31 @@ spec:
           metadataServer:
             activeCount: 1
             activeStandby: false    
+            resources:
+              limits:
+                memory: "750Mi"
+              requests:
+                cpu: "750m"
+                memory: "750Mi"
+            priorityClassName: system-cluster-critical
+        storageClass:
+          enabled: true
+          isDefault: false
+          name: ceph-filesystem
+          pool: data0
+          reclaimPolicy: Delete
+          allowVolumeExpansion: true
+          volumeBindingMode: "Immediate"
+          annotations: {}
+          labels: {}
+          mountOptions: []
+          parameters:
+            csi.storage.k8s.io/provisioner-secret-name: rook-csi-cephfs-provisioner
+            csi.storage.k8s.io/provisioner-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-expand-secret-name: rook-csi-cephfs-provisioner
+            csi.storage.k8s.io/controller-expand-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/controller-publish-secret-name: rook-csi-cephfs-provisioner
+            csi.storage.k8s.io/controller-publish-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/node-stage-secret-name: rook-csi-cephfs-node
+            csi.storage.k8s.io/node-stage-secret-namespace: "{{ .Release.Namespace }}"
+            csi.storage.k8s.io/fstype: ext4

--- a/infrastructure/staging/rook-ceph-cluster/patch-resources.yaml
+++ b/infrastructure/staging/rook-ceph-cluster/patch-resources.yaml
@@ -1,0 +1,72 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+spec:
+  values:
+    cephClusterSpec:
+      mon:
+        count: 1
+      mgr:
+        count: 1
+
+      resources:
+        mon:
+          requests:
+            cpu: "200m"
+            memory: "256Mi"
+          limits:
+            memory: "512Mi"
+        mgr:
+          requests:
+            cpu: "200m"
+            memory: "256Mi"
+          limits:
+            memory: "512Mi"
+        osd:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            memory: "2Gi"
+
+    # This defines a Ceph pool used by RBD (block storage).
+    # PVCs using `rook-ceph-block` → use this pool
+    # -> Databases, StatefulSets, etc. depend on this
+    cephBlockPools:
+      - name: ceph-blockpool
+        spec:
+          # This tells Ceph what “failure” means. (host = a Kubernetes node)
+          # Ceph will try to put replicas on different nodes
+          failureDomain: host
+          # replication factor, ONE copy of data for staging
+          replicated:
+            size: 1
+    
+    cephObjectStores:
+      - name: ceph-objectstore
+        spec:
+          gateway:
+            port: 80
+            instances: 1
+            resources:
+              limits:
+                memory: "1Gi"
+              requests:
+                cpu: "200m"
+                memory: "512Mi"
+    
+    cephFileSystems:
+      - name: ceph-filesystem
+        spec:
+          metadataPool:
+            replicated:
+              size: 1
+          dataPools:
+            - name: data0
+              replicated:
+                size: 1
+          metadataServer:
+            activeCount: 1
+            activeStandby: false    

--- a/infrastructure/staging/rook-ceph-cluster/patch.yaml
+++ b/infrastructure/staging/rook-ceph-cluster/patch.yaml
@@ -1,0 +1,18 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph-cluster
+  namespace: rook-ceph
+spec:
+  values:
+    dashboard:
+      enabled: true
+      ssl: false
+
+    network:
+      connections:
+        encryption:
+          enabled: false
+        compression:
+          enabled: false
+        requireMsgr2: false

--- a/infrastructure/staging/rook-ceph-cluster/patch.yaml
+++ b/infrastructure/staging/rook-ceph-cluster/patch.yaml
@@ -5,9 +5,10 @@ metadata:
   namespace: rook-ceph
 spec:
   values:
-    dashboard:
-      enabled: true
-      ssl: false
+    cephClusterSpec:
+      dashboard:
+        enabled: true
+        ssl: false
 
     network:
       connections:

--- a/infrastructure/staging/rook-ceph-operator/kustomization.yaml
+++ b/infrastructure/staging/rook-ceph-operator/kustomization.yaml
@@ -2,3 +2,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/rook-ceph-operator
+
+patches:
+  - path: patch-resources.yaml
+    target:
+      kind: HelmRelease
+      name: rook-ceph-operator
+      namespace: rook-ceph

--- a/infrastructure/staging/rook-ceph-operator/kustomization.yaml
+++ b/infrastructure/staging/rook-ceph-operator/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base/rook-ceph-operator

--- a/infrastructure/staging/rook-ceph-operator/patch-resources.yaml
+++ b/infrastructure/staging/rook-ceph-operator/patch-resources.yaml
@@ -1,0 +1,46 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: rook-ceph-operator
+  namespace: rook-ceph
+spec:
+  values:
+    csi:
+      csiRBDProvisionerResource: |
+        - name : csi-provisioner
+          resource:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+        - name : csi-attacher
+          resource:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+        - name : csi-resizer
+          resource:
+            requests:
+              memory: 64Mi
+              cpu: 50m
+            limits:
+              memory: 128Mi
+      
+      csiRBDPluginResource: |
+        - name : driver-registrar
+          resource:
+            requests:
+              memory: 64Mi
+              cpu: 25m
+            limits:
+              memory: 128Mi
+        - name : csi-rbdplugin
+          resource:
+            requests:
+              memory: 256Mi
+              cpu: 100m
+            limits:
+              memory: 512Mi


### PR DESCRIPTION
This PR aims to:
- [x] Add distributed, block, object and file storage across nodes
- [x] Configure rook operator monitoring